### PR TITLE
Add safe-area for iPhone x and such type of devices

### DIFF
--- a/lib/pages/HomePage.dart
+++ b/lib/pages/HomePage.dart
@@ -60,22 +60,24 @@ class HomePageState extends State<HomePage> {
   Widget menu() {
     return Container(
       color: Styles.colorPrimary,
-      child: TabBar(
-        indicatorColor: Styles.colorSecondary,
-        tabs: [
-          Tab(
-            text: "Nyheter",
-            icon: Icon(Icons.notifications_active),
-          ),
-          Tab(
-            text: "Program",
-            icon: Icon(Icons.calendar_today),
-          ),
-          Tab(
-            text: "Info",
-            icon: Icon(Icons.info),
-          ),
-        ],
+      child: SafeArea(
+        child: TabBar(
+          indicatorColor: Styles.colorSecondary,
+          tabs: [
+            Tab(
+              text: "Nyheter",
+              icon: Icon(Icons.notifications_active),
+            ),
+            Tab(
+              text: "Program",
+              icon: Icon(Icons.calendar_today),
+            ),
+            Tab(
+              text: "Info",
+              icon: Icon(Icons.info),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The navigation bar at the bottom get's pushed up so that home-button doesn't block any interactions.

 
<img width="545" alt="Screenshot 2019-07-20 at 02 02 51" src="https://user-images.githubusercontent.com/3164065/61571306-aca5b980-aa92-11e9-94eb-4b121c3b93e1.png">
